### PR TITLE
fix: Changes values defined in `SourceMapOptions` to match PostCSS v8 API

### DIFF
--- a/utils/renderPostcss.js
+++ b/utils/renderPostcss.js
@@ -8,7 +8,7 @@ module.exports = function renderPostcss(input, outFile, config, cb) {
     // try to dynamic load of postcss plugins
     /* eslint-disable */
     const runPlugins = plugins.map(plugin => require(plugin));
-    const map = config.general.isProduction ? false : { inline: input.map.toString() } ;
+    const map = config.general.isProduction ? false : { inline: true, prev: input.map.toString() } ;
 
     /* eslint-enable */
     // run postcss plugins at sass output

--- a/utils/renderStyles.js
+++ b/utils/renderStyles.js
@@ -9,7 +9,6 @@ module.exports = function renderStyles(file, dest, config) {
       renderSass(
         dest, file, config, (result, outFile) =>
           renderPostcss(
-            // autoprefix does not need map
             result, outFile, config, postCssResult =>
               // only write file at the end
               writeFile(outFile, postCssResult.css, true)


### PR DESCRIPTION
## Description

Updates options sent to [PostCSS `SourceMapOptions`](https://postcss.org/api/#previousmap-inline) in order to generate correctly the CSS sourcemaps with the paths to the source files.

## Related Issue

Fixes #56.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **[CONTRIBUTING](docs/CONTRIBUTING.mnd)** document.
- [x] All new and existing tests passed.
