### PR TITLE
Feature/18 adapt all paths manipulations with cross os solution

### DIFF
--- a/config/general.config.js
+++ b/config/general.config.js
@@ -9,7 +9,7 @@ const getArgumentValue = require('../utils/getArgumentValue');
 const projectKey = 'myproj';
 
 // root path of the package
-const rootPath = path.resolve('./');
+const rootPath = path.resolve('.');
 
 // source files path
 const sourcesPath = path.join(rootPath, 'src');

--- a/utils/extendConfig.js
+++ b/utils/extendConfig.js
@@ -23,7 +23,7 @@ module.exports = (configPath, config) => {
   }
 
   if (!general.destinationPath) {
-    const parts = override.general.sourcesPath.split(config.general.rootPath)[1].split('/');
+    const parts = override.general.sourcesPath.split(config.general.rootPath)[1].split(path.sep);
     parts[1] = 'dist';
     const dest = path.join(config.general.rootPath, ...parts);
     override.general = override.general || {};

--- a/utils/getClientlib.js
+++ b/utils/getClientlib.js
@@ -6,7 +6,7 @@ module.exports = function getClientlib(original, config) {
   const folder = path.dirname(original);
   const fileName = path.basename(original);
   const clear = new RegExp([...sourceTypes, sourceKey, bundleKey].join('|'), 'gi');
-  const name = folder.replace(clear, '').split('/').join('.');
+  const name = folder.replace(clear, '').split(path.sep).join('.');
 
   return {
     folder,

--- a/utils/log.js
+++ b/utils/log.js
@@ -30,8 +30,7 @@ const colorOptions = {
 const color = (c, str, bg = colorOptions.reset) => `${colorOptions[c]}${str}${bg}`;
 
 const emojis = {
-  // sense of humor?
-  error: [' 😐 🖕 '],
+  error: [' ❌ '],
   success: [' 💪 ']
 };
 

--- a/utils/mkFullPathSync.js
+++ b/utils/mkFullPathSync.js
@@ -1,9 +1,10 @@
 const fs = require('fs');
+const path = require('path');
 
 module.exports = function mkFullPathSync(absolutePath, permissions = '0755') {
   // if is not set to not override
-  absolutePath.split('/').reduce((origin, path) => {
-    const next = `${origin}${path}/`;
+  absolutePath.split(path.sep).reduce((origin, folder) => {
+    const next = `${origin}${folder}${path.sep}`;
     if (!fs.existsSync(next)) fs.mkdirSync(next, permissions);
     return next;
   }, '');


### PR DESCRIPTION
## Description

Replaces hardcoded path separator character "/" with [`path.sep`](https://nodejs.org/api/path.html#pathsep), which provides a platform-specific path segment separator, in order to make the FE Build work in any OS.

## Related Issue

Fixes #18.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **[CONTRIBUTING](docs/CONTRIBUTING.mnd)** document.
- [x] All new and existing tests passed.
  - Tested in Windows 10.
