### PR TITLE
fix(utils): adjust custom missing destination basePath when custom sourcesPath defined

### DIFF
--- a/utils/extendConfig.js
+++ b/utils/extendConfig.js
@@ -17,13 +17,16 @@ module.exports = (configPath, config) => {
   // this allows our .febuild create its own config per folder
   // if sourcesPath is not provided, .febuild file location is used
   const { general = {} } = override;
+  let basePath = general.sourcesPath;
+
   if (!general.sourcesPath) {
     override.general = override.general || {};
     override.general.sourcesPath = path.dirname(dir);
+    basePath = override.general.sourcesPath.split(config.general.rootPath)[1];
   }
 
   if (!general.destinationPath) {
-    const parts = override.general.sourcesPath.split(config.general.rootPath)[1].split(path.sep);
+    const parts = basePath.split(path.sep);
     parts[1] = 'dist';
     const dest = path.join(config.general.rootPath, ...parts);
     override.general = override.general || {};


### PR DESCRIPTION
## Description

When there is a custom `sourcesPath` defined in `.febuild` file, and no `destinationPath`, this `destinationPath` is not correctly obtained since it's considering  `sourcesPath` will start with `config.general.rootPath`, and that's not the case.

## Related Issue

Fixes #70 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [X] I have read the **[CONTRIBUTING](docs/CONTRIBUTING.mnd)** document.
- [X] All new and existing tests passed.
