### PR TITLE
Adds option to disable Stylelint

### DIFF
--- a/config/general.config.js
+++ b/config/general.config.js
@@ -77,6 +77,9 @@ const quiet = getArgumentValue('--quiet');
 // analyzerPort
 const analyzerPort = getArgumentValue('--port=') || 8888;
 
+// disable Stylelint
+const disableStyleLint = getArgumentValue('--disable-styelint');
+
 // general webpack
 const devtool = isProduction ? 'none' : 'inline-source-map';
 
@@ -105,6 +108,7 @@ module.exports = {
   watch,
   analyze,
   analyzerPort,
+  disableStyleLint,
   task,
   quiet,
   configFile,

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -58,3 +58,13 @@ Analyze the bundles with [Webpack Bundle Analyzer](https://www.npmjs.com/package
     "analyze": "nc-fe-build --task=webpack --analyze --development"
   }
 ```
+
+To change the port number, you can append the argument `--port=` followed by a valid port number.
+
+# Additional Arguments
+You can add the following arguments to the `nc-fe-build` command in order to change its behavior.
+
+| Argument  | Description |
+| --------- | ----------- |
+| `--quiet` | Displays less messages in the output |
+| `--disable-styelint` | Disables Stylelint |

--- a/utils/runStylelint.js
+++ b/utils/runStylelint.js
@@ -4,8 +4,12 @@ const linterError = require('./linterError');
 
 module.exports = function runStylelint(files, projectConfig, cb) {
   // extract from config
-  const { syntax, failOnError } = projectConfig.stylelint;
+  const { failOnError } = projectConfig.stylelint;
   const { rootPath } = projectConfig.general;
+
+  if (projectConfig.general.disableStyleLint) {
+    return cb();
+  }
 
   log(__filename, 'Stylelint');
 


### PR DESCRIPTION
## Description

Stylelint runs always when executing the build and there is no way to disable it. There are scenarios where a user would need  to disabled Stylelint, like when deploying to a server using CI.

## Related Issue

Fixes #15

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **[CONTRIBUTING](docs/CONTRIBUTING.mnd)** document.
- [x] All new and existing tests passed.
