### PR TITLE
Update remote repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/netcentric/fe-build"
+    "url": "https://github.com/Netcentric/fe-build.git "
   },
   "scripts": {
     "test": "echo \"Error: no test specified\""


### PR DESCRIPTION
## Description

The name of the repository has changed from
"github.com/netcentric"
to
"github.com/Netcentric"
and apparently it caused an [error in the Release action](https://github.com/Netcentric/fe-build/runs/7893681059?check_suite_focus=true):
>Error: Error: Command failed with exit code 1: git push --tags https://github.com/netcentric/fe-build HEAD:main
>remote: This repository moved. Please use the new location:        
>remote:   https://github.com/Netcentric/fe-build.git       

This PR tries to fix it.