### PR TITLE
fix(utils): Fix category name generation to prevent consecutive dots and leading dots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@netcentric/fe-build",
-  "version": "5.0.0",
+  "version": "5.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@netcentric/fe-build",
-      "version": "5.0.0",
+      "version": "5.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.26.7",

--- a/utils/getClientlib.js
+++ b/utils/getClientlib.js
@@ -6,7 +6,10 @@ module.exports = function getClientlib(original, config) {
   const folder = path.dirname(original);
   const fileName = path.basename(original);
   const clear = new RegExp([...sourceTypes, sourceKey, bundleKey].join('|'), 'gi');
-  const name = folder.replace(clear, '').split(path.sep).join('.');
+  const name = folder.replace(clear, '')
+    .split(path.sep)
+    .filter((categoryItem, idx) => categoryItem && (idx !== 0 || categoryItem.charAt(0) !== '.'))
+    .join('.');
 
   return {
     folder,


### PR DESCRIPTION
Ensures the build process produces correct and expected results OOTB.

## Description

Filtered category parts to ensure:  
- No consecutive dots (`..`) in the generated category name  
- The category name does not start with a dot (`.`)  

## Related Issue
Fixes #118 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have read the **[CONTRIBUTING](docs/CONTRIBUTING.md)** document.
- [X] All new and existing tests passed.
