### PR TITLE
Fix category name generation to prevent consecutive dots and leading dots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@netcentric/fe-build",
-  "version": "5.0.0",
+  "version": "5.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@netcentric/fe-build",
-      "version": "5.0.0",
+      "version": "5.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.26.7",

--- a/tasks/clientlibs.js
+++ b/tasks/clientlibs.js
@@ -18,8 +18,7 @@ module.exports = (config) => {
 
   // get parse to check if it has css or js or both.
   Object.keys(entries).forEach((entryKey) => {
-    const { name, folder, fileName } = getClientlib(entryKey, config);
-    const extension = entryKey.split('.').pop();
+    const { name, folder, fileName, extension } = getClientlib(entryKey);
 
     if (!clientLibs[folder]) {
       clientLibs[folder] = { name, folder };

--- a/tasks/clientlibs.test.js
+++ b/tasks/clientlibs.test.js
@@ -24,7 +24,7 @@ describe('Test task/clientlibs.js', () => {
         const file = path.join(destinationPath, entry);
         const type = path.extname(file);
         const dir = path.dirname(file);
-        const { name, fileName } = getClientlib(entry, config);
+        const { name, fileName } = getClientlib(entry);
         const ext = type == '.js' ? 'js' : 'css';
         const txtContet = `${fileName.split('.').slice(0, -1).join('.')}.${ext}`;
         const txtPath = path.join(dir, `${ext}.txt`);

--- a/utils/getClientlib.js
+++ b/utils/getClientlib.js
@@ -1,16 +1,16 @@
 const path = require('path');
 
-module.exports = function getClientlib(original, config) {
-  // extract from config
-  const { sourceTypes, sourceKey, bundleKey } = config.general;
+module.exports = function getClientlib(original) {
+
   const folder = path.dirname(original);
   const fileName = path.basename(original);
-  const clear = new RegExp([...sourceTypes, sourceKey, bundleKey].join('|'), 'gi');
-  const name = folder.replace(clear, '').split(path.sep).join('.');
+  const name = folder.split(path.sep).join('.');
+  const extension = original.split('.').pop();
 
   return {
     folder,
     name,
-    fileName
+    fileName,
+    extension,
   };
 };

--- a/utils/getClientlib.test.js
+++ b/utils/getClientlib.test.js
@@ -1,22 +1,19 @@
 process.argv.push('--quiet');
 const path = require('path');
-const defaults = require('../config');
-const extendConfig = require('./extendConfig');
-const generateEntries = require('./generateEntries');
 const getClientlib = require("./getClientlib");
 
-const config = extendConfig('./test/.febuild', defaults);
-
 describe('Test utils/getClientlib.js', () => {
-    
+
     it('Should return from a file location the required info for a clientlib, eg category name, file to import into js.txt etc', () => {
         const fileName = 'component.bundle.js';
         const folder = 'publish/content/component';
+        const extension = 'js';
         const location = `${folder}${path.sep}${fileName}`;
-        const clientlibNameCategory = 'publish.content.component'
-        const clientlib = getClientlib(location, config);
+        const clientlibNameCategory = 'publish.content.component';
+        const clientlib = getClientlib(location);
         expect(clientlib.name).toBe(clientlibNameCategory);
         expect(clientlib.fileName).toBe(fileName);
         expect(clientlib.folder).toBe(folder);
+        expect(clientlib.extension).toBe(extension);
     });
 })


### PR DESCRIPTION
Ensures the build process produces correct and expected results OOTB.

## Description

Filtered category parts to ensure:  
- No consecutive dots (`..`) in the generated category name  
- The category name does not start with a dot (`.`)  

## Related Issue
Fixes #118 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have read the **[CONTRIBUTING](docs/CONTRIBUTING.md)** document.
- [X] All new and existing tests passed.
