### PR TITLE
feat(config): Support clientlib metadata generation for dynamically created CSS files

### DIFF
--- a/config/clientlibs.config.js
+++ b/config/clientlibs.config.js
@@ -13,7 +13,11 @@ const skipCategories = ['myproject.author'];
 // extra XML params to append to .content.xml use key=value
 // linter disabled since we are requirement to send $\{ to a template string
 
+// Object to be able to generate clientlibs for new CSS files (created in build process) in target folder
+const extraEntries = {};
+
 module.exports = {
   override,
-  skipCategories
+  skipCategories,
+  extraEntries,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@netcentric/fe-build",
-  "version": "5.1.3",
+  "version": "5.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@netcentric/fe-build",
-      "version": "5.1.3",
+      "version": "5.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.26.7",

--- a/tasks/clientlibs.js
+++ b/tasks/clientlibs.js
@@ -7,11 +7,20 @@ const renderClientLibs = require('../utils/renderClientLibs');
 module.exports = (config) => {
   log(__filename, 'clientlibs task running...', '', 'info');
 
+  const { extraEntries } = config.postcss;
+
   // checking all entries at this configuration
-  const entries = {
+  let entries = {
     ...generateEntries(config),
-    ...generateEntries(config, 'scss')
+    ...generateEntries(config, 'scss'),
   };
+
+  entries = {
+    ...entries,
+    ...extraEntries ? {
+      ...generateEntries(config, extraEntries.extension, extraEntries.filenamePattern, extraEntries.cwd),
+    } : null,
+  }
 
   // clientlibs to render
   const clientLibs = {};

--- a/utils/generateEntries.js
+++ b/utils/generateEntries.js
@@ -1,9 +1,9 @@
 const glob = require('fast-glob');
 const path = require('path');
 
-module.exports = function generateEntries(config, extension = 'js') {
-  const sourcePattern = `**/*.${config.general.sourceKey}.${extension}`;
-  const sourcesFiles = glob.sync(sourcePattern, { cwd: config.general.sourcesPath });
+module.exports = function generateEntries(config, extension = 'js', filenamePattern = config.general.sourceKey, cwd = config.general.sourcesPath) {
+  const sourcePattern = `**/*.${filenamePattern}.${extension}`;
+  const sourcesFiles = glob.sync(sourcePattern, { cwd: cwd });
 
   // if is multiple entries
   if (config && config.general && config.general.multiple) {
@@ -12,9 +12,9 @@ module.exports = function generateEntries(config, extension = 'js') {
     sourcesFiles.forEach((file) => {
       const dir = path.dirname(file);
       const fileName = path.basename(file);
-      const destFileName = fileName.replace(config.general.sourceKey, config.general.bundleKey);
+      const destFileName = fileName.replace(filenamePattern, config.general.bundleKey);
       const destFile = path.join(dir, destFileName);
-      sources[destFile] = path.join(config.general.sourcesPath, file);
+      sources[destFile] = path.join(cwd, file);
     });
 
     return sources;

--- a/utils/renderClientLibs.js
+++ b/utils/renderClientLibs.js
@@ -34,6 +34,12 @@ module.exports = function renderClientLibs(clientLibObject, config) {
     writeFile(path.join(absolutePath, 'js.txt'), `${js}`, override);
   }
 
+  const extensionFile = config.postcss.extraEntries?.extension;
+  const hasExtraEntries = extensionFile && clientLibObject[extensionFile];
+  if ( hasExtraEntries ) {
+    writeFile(path.join(absolutePath, `${extensionFile}.txt`), `${js}`, override);
+  }
+
   // write .content.xml
   const content = clientlibTemplate(name, projectKey);
   writeFile(path.join(absolutePath, '.content.xml'), content, override);


### PR DESCRIPTION
This PR adds support for generating `.content.xml` and `css.txt` files for CSS files created dynamically during the build process (e.g., via PostCSS plugins). 
These files are essential for enabling AEM to recognize and serve the generated clientlibs correctly.

## Description

- Introduced a new extraEntries configuration option in PostCSS processing to allow metadata generation for target files.
- Supports specifying:
```javascript
extraEntries: {
  extension: 'css',
  cwd: destinationPath,
  filenamePattern: 'clientlibs-*',
}
```
- Ensures metadata is generated for CSS files matching the given pattern in the specified output directory.


## Related Issue
Fixes #126 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have read the **[CONTRIBUTING](docs/CONTRIBUTING.md)** document.
- [X] All new and existing tests passed.
