### PR TITLE
fix(utils): Fix incorrect metadata content for postcss extraEntries

### DIFF
--- a/utils/renderClientLibs.js
+++ b/utils/renderClientLibs.js
@@ -36,8 +36,9 @@ module.exports = function renderClientLibs(clientLibObject, config) {
 
   const extensionFile = config.postcss.extraEntries?.extension;
   const hasExtraEntries = extensionFile && clientLibObject[extensionFile];
+  const fileName = clientLibObject[extensionFile];
   if ( hasExtraEntries ) {
-    writeFile(path.join(absolutePath, `${extensionFile}.txt`), `${js}`, override);
+    writeFile(path.join(absolutePath, `${extensionFile}.txt`), `${fileName}`, override);
   }
 
   // write .content.xml


### PR DESCRIPTION
## Description

This PR fixes an issue in the FE Build where metadata files generated for postcss.extraEntries may contain incorrect content. The problem was caused by always writing the js variable instead of the specific entry defined for the extension.

The logic has been updated to correctly reference the appropriate file content from clientLibObject, ensuring accurate metadata generation.

## Related Issue

Fixes #129 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [X] I have read the **[CONTRIBUTING](docs/CONTRIBUTING.md)** document.
- [X] All new and existing tests passed.
