### PR TITLE
fix(tasks): update styles watcher to support chokidar v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@netcentric/fe-build",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@netcentric/fe-build",
-      "version": "5.3.1",
+      "version": "5.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.26.7",
@@ -14,7 +14,7 @@
         "@babel/preset-env": "^7.26.7",
         "autoprefixer": "^10.4.20",
         "babel-loader": "9.1.2",
-        "chokidar": "^5.0.0",
+        "chokidar": "^4.0.3",
         "core-js": "^3.40.0",
         "eslint": "^8.57.1",
         "eslint-webpack-plugin": "^4.2.0",
@@ -3329,15 +3329,14 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "license": "MIT",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dependencies": {
-        "readdirp": "^5.0.0"
+        "readdirp": "^4.0.1"
       },
       "engines": {
-        "node": ">= 20.19.0"
+        "node": ">= 14.16.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -5973,12 +5972,11 @@
       "license": "MIT"
     },
     "node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "license": "MIT",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "engines": {
-        "node": ">= 20.19.0"
+        "node": ">= 14.18.0"
       },
       "funding": {
         "type": "individual",
@@ -6206,34 +6204,6 @@
       },
       "optionalDependencies": {
         "@parcel/watcher": "^2.4.1"
-      }
-    },
-    "node_modules/sass/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/sass/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/schema-utils": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/preset-env": "^7.26.7",
     "autoprefixer": "^10.4.20",
     "babel-loader": "9.1.2",
-    "chokidar": "^5.0.0",
+    "chokidar": "^4.0.3",
     "core-js": "^3.40.0",
     "eslint": "^8.57.1",
     "eslint-webpack-plugin": "^4.2.0",

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -1,19 +1,25 @@
 const path = require('path');
+const glob = require('fast-glob');
 const { log } = require('../utils/log');
 const generateEntries = require('../utils/generateEntries');
 const renderStyles = require('../utils/renderStyles');
 
 // extend log to proper say what file is running
 module.exports = (config) => {
-  return new Promise((resolve) => {
+  return new Promise(async (resolve) => {
     if (config && config.general && config.general.watch) {
       try {
         log(__filename, 'Watcher Sass / autoprefixer running...', '', 'info');
 
         const chokidar = require('chokidar')
-        const sassPattern = path.join(config.general.sourcesPath, `**/*.${config.general.sourceKey}.scss`);
+        const pattern = `**/*.${config.general.sourceKey}.scss`
 
-        const watcher = chokidar.watch(sassPattern, {
+        const files = await glob(pattern, {
+          cwd: config.general.sourcesPath,
+          absolute: true
+        })
+
+        const watcher = chokidar.watch(files, {
           ignoreInitial: true
         })
 

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -5,54 +5,52 @@ const generateEntries = require('../utils/generateEntries');
 const renderStyles = require('../utils/renderStyles');
 
 // extend log to proper say what file is running
-module.exports = (config) => {
-  return new Promise(async (resolve) => {
-    if (config && config.general && config.general.watch) {
-      try {
-        log(__filename, 'Watcher Sass / autoprefixer running...', '', 'info');
+module.exports = async (config) => {
+  if (config && config.general && config.general.watch) {
+    try {
+      log(__filename, 'Watcher Sass / autoprefixer running...', '', 'info');
 
-        const chokidar = require('chokidar')
-        const pattern = `**/*.${config.general.sourceKey}.scss`
+      const chokidar = require('chokidar');
+      const pattern = `**/*.${config.general.sourceKey}.scss`;
 
-        const files = await glob(pattern, {
-          cwd: config.general.sourcesPath,
-          absolute: true
-        })
-
-        const watcher = chokidar.watch(files, {
-          ignoreInitial: true
-        })
-
-        watcher.on('all', (event, file) => {
-          const relativePath = path.relative(
-            config.general.sourcesPath,
-            path.dirname(file)
-          )
-
-          const fileName = path
-            .basename(file)
-            .replace(config.general.sourceKey, config.general.bundleKey)
-
-          const destFile = path.join(relativePath, fileName)
-
-          config.stylelint.failOnError = false
-
-          renderStyles(file, destFile, config)
-        });
-
-      } catch (e) {
-        log(__filename, 'Something is missing, you need install dev dependencies for this.', e.message, 'error');
-      }
-    } else {
-      log(__filename, 'Sass / autoprefixer running...', '', 'info');
-
-      // checking all entries at this configuration
-      const entries = generateEntries(config, 'scss');
-      const promises = Object.keys(entries).map(file => renderStyles(entries[file], file, config));
-      Promise.allSettled(promises).then((results) => {
-        log(__filename, 'Styles done', '', 'info');
-        resolve();
+      // Note: fast-glob resolves files once at startup, so newly created SCSS files
+      // won't be picked up by the watcher without a restart. This is an accepted
+      // tradeoff to avoid EMFILE errors with recursive directory watching.
+      const files = await glob(pattern, {
+        cwd: config.general.sourcesPath,
+        absolute: true
       });
+
+      const watcher = chokidar.watch(files, {
+        ignoreInitial: true
+      });
+
+      watcher.on('all', (event, file) => {
+        const relativePath = path.relative(
+          config.general.sourcesPath,
+          path.dirname(file)
+        );
+
+        const fileName = path
+          .basename(file)
+          .replace(config.general.sourceKey, config.general.bundleKey);
+
+        const destFile = path.join(relativePath, fileName);
+
+        config.stylelint.failOnError = false;
+
+        renderStyles(file, destFile, config);
+      });
+
+    } catch (e) {
+      log(__filename, 'Something is missing, you need install dev dependencies for this.', e.message, 'error');
     }
-  });
+  } else {
+    log(__filename, 'Sass / autoprefixer running...', '', 'info');
+
+    const entries = generateEntries(config, 'scss');
+    const promises = Object.keys(entries).map(file => renderStyles(entries[file], file, config));
+    await Promise.allSettled(promises);
+    log(__filename, 'Styles done', '', 'info');
+  }
 };

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -21,6 +21,11 @@ module.exports = async (config) => {
         absolute: true
       });
 
+      if (!files.length) {
+        log(__filename, 'No SCSS sources found to watch', '', 'warn');
+        return;
+      }
+
       const watcher = chokidar.watch(files, {
         ignoreInitial: true
       });
@@ -43,7 +48,7 @@ module.exports = async (config) => {
       });
 
     } catch (e) {
-      log(__filename, 'Something is missing, you need install dev dependencies for this.', e.message, 'error');
+      log(__filename, 'Failed to start SCSS watcher', e.message, 'error');
     }
   } else {
     log(__filename, 'Sass / autoprefixer running...', '', 'info');

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -26,6 +26,8 @@ module.exports = async (config) => {
         return;
       }
 
+      config.stylelint.failOnError = false;
+
       const watcher = chokidar.watch(files, {
         ignoreInitial: true
       });
@@ -41,8 +43,6 @@ module.exports = async (config) => {
           .replace(config.general.sourceKey, config.general.bundleKey);
 
         const destFile = path.join(relativePath, fileName);
-
-        config.stylelint.failOnError = false;
 
         renderStyles(file, destFile, config);
       });

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -22,7 +22,7 @@ module.exports = async (config) => {
       });
 
       if (!files.length) {
-        log(__filename, 'No SCSS sources found to watch', '', 'warn');
+        log(__filename, 'No SCSS sources found to watch', '', 'warning');
         return;
       }
 


### PR DESCRIPTION
This PR fixes an issue with SCSS file watchers caused by Chokidar version > 3. In versions 4+, Chokidar no longer supports glob patterns directly.

## Description
Chokidar v4 removed support for glob patterns in `watch()`. 
This PR updates the styles watcher to handle that breaking change by pre-resolving SCSS files  via `fast-glob` before passing them to chokidar.         

## Related Issue
Fixes #138 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **[CONTRIBUTING](docs/CONTRIBUTING.md)** document.
- [x] All new and existing tests passed.
