### PR TITLE
feat(config): add failOnError property to sass configuration

### DIFF
--- a/config/sass.config.js
+++ b/config/sass.config.js
@@ -8,5 +8,6 @@ module.exports = {
   includePaths,
   outputStyle,
   // for any https://sass-lang.com/documentation/js-api/interfaces/options/ options
-  adicionalOptions: {}
+  adicionalOptions: {},
+  failOnError: true,
 };


### PR DESCRIPTION
## Description
This PR adds the missing `failOnError` property to `sass.config.js`.
Tasks and utils expect this property to exist in config.sass, but it was previously undefined.
Adding failOnError ensures consistency across configuration files and prevents potential errors or unexpected behavior during Sass-related builds.

## Related Issue
Fixes #142 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have read the **[CONTRIBUTING](docs/CONTRIBUTING.md)** document.
- [X] All new and existing tests passed.
