### PR TITLE
ci: use RELEASE_PAT to bypass branch protection for semantic-release

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -17,7 +17,7 @@ on:
         default: true
 # ENV and Config
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   GIT_AUTHOR_NAME: github-actions
   GIT_AUTHOR_EMAIL: github-actions@github.com

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
             @semantic-release/changelog
             @semantic-release/git
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GIT_AUTHOR_NAME: github-actions
           GIT_AUTHOR_EMAIL: github-actions@github.com


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above 
      Use Angular Commit Message Conventions in commits - 
      https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-header
-->

## Description

<!--- Describe your changes in detail -->

**Temp fix: use `RELEASE_PAT` to unblock semantic-release on `main`**

Closes #147, ref #146.

The default `GITHUB_TOKEN` cannot bypass branch protection, causing the release workflow to fail with `GH006` on every push to `main`. This swaps in `RELEASE_PAT` (a fine-grained PAT scoped to this repo, Contents: Read and write) as a temporary fix while the org GitHub App is provisioned.

**Changes:**
- `release.yml` - `GITHUB_TOKEN` -> `RELEASE_PAT`
- `manual-release.yml` - `GITHUB_TOKEN` -> `RELEASE_PAT`

**Verified via** `manual-release.yml` dry-run on this branch - no `GH006` error.

**This is temporary.** Remove `RELEASE_PAT` and revert these changes once the GitHub App solution from #146 is in place.
## Related Issue

https://github.com/Netcentric/fe-build/issues/147

<!--- This project only accepts pull requests related to open issues
      If suggesting a new feature or change, please discuss it in an issue first
      If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--
      To automatically close linked issue when PR is merged.
      Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have read the **[CONTRIBUTING](docs/CONTRIBUTING.md)** document.
- [x] All new and existing tests passed.
